### PR TITLE
Use expected \Monolog\LogRecord object in handler

### DIFF
--- a/src/Monolog/Handler/LogdnaHandler.php
+++ b/src/Monolog/Handler/LogdnaHandler.php
@@ -79,13 +79,13 @@ class LogdnaHandler extends \Monolog\Handler\AbstractProcessingHandler {
     }
 
     /**
-     * @param array $record
+     * @param \Monolog\LogRecord $record
      */
-    protected function write(array $record): void {
+    protected function write(\Monolog\LogRecord $record): void {
         $headers = ['Content-Type: application/json'];
-        $data = $record["formatted"];
+        $data = $record->formatted;
 
-        $url = \sprintf("https://logs.logdna.com/logs/ingest?hostname=%s&mac=%s&ip=%s&now=%s", $this->hostname, $this->mac, $this->ip, $record['datetime']->getTimestamp());
+        $url = \sprintf("https://logs.logdna.com/logs/ingest?hostname=%s&mac=%s&ip=%s&now=%s", $this->hostname, $this->mac, $this->ip, $record->datetime->getTimestamp());
 
         \curl_setopt($this->curl_handle, CURLOPT_URL, $url);
         \curl_setopt($this->curl_handle, CURLOPT_USERPWD, "$this->ingestion_key:");


### PR DESCRIPTION
In version 3.x, Monolog has updated from using a simple array to represent the log record, to using a dedicated `LogRecord` object to represent the log record in the `AbstractProcessingHandler`, which the `LogdnaHandler` class extends.

In this PR, the `LogdnaHandler` has been updated to accept the `\Monolog\LogRecord` object as parameter over the `$record` array.

Source: https://github.com/Seldaek/monolog/blob/main/UPGRADE.md
> Log records have been converted from an array to a [Monolog\LogRecord object](https://github.com/Seldaek/monolog/blob/main/src/Monolog/LogRecord.php) with public (and mostly readonly) properties. e.g. instead of doing $record['context'] use $record->context. In formatters or handlers if you rather need an array to work with you can use $record->toArray() to get back a Monolog 1/2 style record array. This will contain the enum values instead of enum cases in the level and level_name keys to be more backwards compatible and use simpler data types.

@nvanheuverzwijn 