### PR TITLE
Fix objects in context array being lost

### DIFF
--- a/src/Monolog/Formatter/LogdnaFormatter.php
+++ b/src/Monolog/Formatter/LogdnaFormatter.php
@@ -35,6 +35,7 @@ class LogdnaFormatter extends \Monolog\Formatter\JsonFormatter {
                 ]
             ]
         ];
-        return $json;
+
+        return $this->normalize($json);
     }
 }

--- a/tests/Monolog/Formatter/LogdnaFormatterTest.php
+++ b/tests/Monolog/Formatter/LogdnaFormatterTest.php
@@ -33,8 +33,9 @@ class LogdnaFormatterTest extends TestCase
                 'class' => \Exception::class,
                 'message' => 'This is a test exception',
                 'code' => 42,
-                'file' => __FILE__ . ':48',
+                'file' => __FILE__ . ':' . __LINE__ + 13,
             ],
+            'foo' => 'bar',
         ]);
     }
 
@@ -45,7 +46,7 @@ class LogdnaFormatterTest extends TestCase
             'name',
             \Monolog\Level::Debug,
             'some message',
-            ['exception' => new \Exception('This is a test exception', 42)],
+            ['exception' => new \Exception('This is a test exception', 42), 'foo' => 'bar'],
         );
     }
 

--- a/tests/Monolog/Formatter/LogdnaFormatterTest.php
+++ b/tests/Monolog/Formatter/LogdnaFormatterTest.php
@@ -28,8 +28,14 @@ class LogdnaFormatterTest extends TestCase
         $this->assertEquals($decoded_json['lines'][0]['line'], $record->message);
         $this->assertEquals($decoded_json['lines'][0]['app'], $record->channel);
         $this->assertEquals($decoded_json['lines'][0]['level'], $record->level->toPsrLogLevel());
-        $this->assertEquals($decoded_json['lines'][0]['meta'], $record->context);
-
+        $this->assertEquals($decoded_json['lines'][0]['meta'], [
+            'exception' => [
+                'class' => \Exception::class,
+                'message' => 'This is a test exception',
+                'code' => 42,
+                'file' => __FILE__ . ':48',
+            ],
+        ]);
     }
 
     private function getRecord(): \Monolog\LogRecord
@@ -39,7 +45,7 @@ class LogdnaFormatterTest extends TestCase
             'name',
             \Monolog\Level::Debug,
             'some message',
-
+            ['exception' => new \Exception('This is a test exception', 42)],
         );
     }
 


### PR DESCRIPTION
@nvanheuverzwijn It looks like there is an issue in the `LogdnaFormatter` class that causes objects in the `context` array to be lost. In our case, we pass exceptions via `context`, but they're discarded/missing in Mezmo:

![image](https://user-images.githubusercontent.com/645637/231523166-0c3010f0-3ea3-4e91-bca8-39d4736c2195.png)

The issue occurs because the log record array isn't being run through `$this->normalize()`. I've added this method call and updated the tests.