### PR TITLE
Allow set Logdna tags on handler

### DIFF
--- a/src/Monolog/Handler/LogdnaHandler.php
+++ b/src/Monolog/Handler/LogdnaHandler.php
@@ -42,6 +42,11 @@ class LogdnaHandler extends \Monolog\Handler\AbstractProcessingHandler {
     private $mac = '';
 
     /**
+     * @var string $tags
+     */
+    private $tags = '';
+
+    /**
      * @var resource $curl_handle
      */
     private $curl_handle;
@@ -58,6 +63,13 @@ class LogdnaHandler extends \Monolog\Handler\AbstractProcessingHandler {
      */
     public function setMAC($value) {
         $this->mac = $value;
+    }
+
+    /**
+     * @param string $tags
+     */
+    public function setTags($tags) {
+        $this->tags = $tags;
     }
 
     /**
@@ -85,7 +97,13 @@ class LogdnaHandler extends \Monolog\Handler\AbstractProcessingHandler {
         $headers = ['Content-Type: application/json'];
         $data = $record->formatted;
 
-        $url = \sprintf("https://logs.logdna.com/logs/ingest?hostname=%s&mac=%s&ip=%s&now=%s", $this->hostname, $this->mac, $this->ip, $record->datetime->getTimestamp());
+        $query = [
+            'hostname' => $this->hostname,
+            'mac' => $this->mac,
+            'ip' => $this->ip,
+            'tags' => $this->tags
+        ];
+        $url = 'https://logs.logdna.com/logs/ingest?' . \http_build_query(\array_filter($query));
 
         \curl_setopt($this->curl_handle, CURLOPT_URL, $url);
         \curl_setopt($this->curl_handle, CURLOPT_USERPWD, "$this->ingestion_key:");


### PR DESCRIPTION
This PR allows to set Logdna tags on the monolog handler like this

```
$handler = new LogdnaHandler($key, $host);
$handler->setTags($tags);
```

The way the query params are generated is also slightly improved from `sprintf` to `http_build_query+array_filter`, since the tags can be anything it should be at least `urlencode()`'d which is handled by `http_build_query`. The `array_filter` could potentialy remove "0"'s but i don't think that was ever a valid input for the other params so it should not break anything, but ultimately it may not be necesary, but sending empty params isnt necesary either, so i included it for now, but i can remove it if you want.