### PR TITLE
Allow add record extra to logdna metadata

### DIFF
--- a/src/Monolog/Formatter/LogdnaFormatter.php
+++ b/src/Monolog/Formatter/LogdnaFormatter.php
@@ -17,6 +17,15 @@ namespace Zwijn\Monolog\Formatter;
  */
 class LogdnaFormatter extends \Monolog\Formatter\JsonFormatter {
 
+    /**
+     * @var bool $addExtraToMeta
+     */
+    private $addExtraToMeta = false;
+
+    public function addExtraToMeta($enable) {
+        $this->addExtraToMeta = $enable;
+    }
+
     public function __construct(int $batchMode = self::BATCH_MODE_NEWLINES, bool $appendNewline = false, bool $ignoreEmptyContextAndExtra = false, bool $includeStacktraces = false) {
         parent::__construct($batchMode, $appendNewline, $ignoreEmptyContextAndExtra, $includeStacktraces);
     }
@@ -31,9 +40,9 @@ class LogdnaFormatter extends \Monolog\Formatter\JsonFormatter {
                     'line' => $record->message,
                     'app' => $record->channel,
                     'level' => $record->level->toPsrLogLevel(),
-                    'meta' => $record->context
-                ]
-            ]
+                    'meta' => $this->addExtraToMeta ? $record->context + $record->extra : $record->context,
+                ],
+            ],
         ];
 
         return $this->normalize($json);


### PR DESCRIPTION
Hello,

Currently only `$record->context` is included in data sent to logdna, but that only contains `$context` which was passed from the logger caller like:

```
$logger->log($level, $message, $context);
```

But monolog processors may fill records with extra data which is available in a property (`$record->extra`) that is currently not included in the payload sent to logdna.

In this PR I added the posibility to include the `$record->extra` in the logdna entry metadata.

Who want to use it must instantiate non default formatter like:

```
$handler = new LogdnaHandler($key, $host);

$formatter = new LogdnaFormatter();
$formatter->addExtraToMeta(true);
$handler->setFormatter($formatter);
```

If you'd like a different way of setup or even make it the default I'm all in for discussion.

I'm also not sure whether the array union is ok (`$record->context + $record->extra`) or if it would be better handled with `array_merge` or even let a callback be passed from outside... what do you think?