### PR TITLE
Remove ignoreEmptyContextAndExtra param from LogdnaFormatter constructor

### DIFF
--- a/src/Monolog/Formatter/LogdnaFormatter.php
+++ b/src/Monolog/Formatter/LogdnaFormatter.php
@@ -17,7 +17,14 @@ namespace Zwijn\Monolog\Formatter;
  */
 class LogdnaFormatter extends \Monolog\Formatter\JsonFormatter {
 
-    public function __construct(int $batchMode = self::BATCH_MODE_NEWLINES, bool $appendNewline = false, bool $ignoreEmptyContextAndExtra = false, bool $includeStacktraces = false) {
+    public function __construct(int $batchMode = self::BATCH_MODE_NEWLINES, bool $appendNewline = false, bool $includeStacktraces = false) {
+        /**
+         * The value is ignored in this implementation and effectively does nothing in the parent.
+         * We can set it to anything and this formatter would be functionally equivalent.
+         * Although semantically this formatter behaves as if it was true,
+         * we set it to false to skip a few useless instructions in the parent implementation.
+         */
+        $ignoreEmptyContextAndExtra = false;
         parent::__construct($batchMode, $appendNewline, $ignoreEmptyContextAndExtra, $includeStacktraces);
     }
 


### PR DESCRIPTION
Following discussion from #16

The param is used here in the parent:
https://github.com/Seldaek/monolog/blob/main/src/Monolog/Formatter/JsonFormatter.php#L89

But that only happens when `format()` resp. `normalizeRecord()` returns array with keys `context` and/or `extra`, but this is never happening in the `LogdnaFormatter`, and so that parameter has no effect.

This is a BC for those instantiating the formatter themselves with 3 or 4 arguments (or using named arguments).