### PR TITLE
Send logdna now argument in milliseconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ By default, the handler sends `now` parameter to the [Ingestion API](https://doc
 which is used to calculate time drift. You can disable sending this parameter via
 
 ```
-$handler->setIncludeRequestTime(false);
+$logdnaHandler->setIncludeRequestTime(false);
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ Monolog Processors may add some extra data to the log records.
 This data will appear in logdna log metadata as property `monolog_extra` unless it is empty.
 If such a property already exists in the log record's `context`, it will be overwritten.
 
+## Time Drift Calculation
+
+By default, the handler sends `now` parameter to the [Ingestion API](https://docs.mezmo.com/log-analysis-api#ingest), 
+which is used to calculate time drift. You can disable sending this parameter via
+
+```
+$handler->setIncludeRequestTime(false);
+```
+
 ## License
 
 This project is licensed under LGPL3.0. See `LICENSE` file for details.

--- a/src/Monolog/Handler/LogdnaHandler.php
+++ b/src/Monolog/Handler/LogdnaHandler.php
@@ -80,6 +80,9 @@ class LogdnaHandler extends \Monolog\Handler\AbstractProcessingHandler
         $this->tags = $tags;
     }
 
+    /**
+     * @param bool $include
+     */
     public function setIncludeRequestTime($include)
     {
         $this->include_request_time = $include;
@@ -120,7 +123,7 @@ class LogdnaHandler extends \Monolog\Handler\AbstractProcessingHandler
         ];
 
         if ($this->include_request_time) {
-            $query['now'] = $this->getCurrentTimeInMilliseconds();
+            $query['now'] = (string) \floor(\microtime(true) * 1000.0);
         }
 
         $url = 'https://logs.mezmo.com/logs/ingest?' . \http_build_query(\array_filter($query));
@@ -142,12 +145,5 @@ class LogdnaHandler extends \Monolog\Handler\AbstractProcessingHandler
     protected function getDefaultFormatter(): FormatterInterface
     {
         return new \Zwijn\Monolog\Formatter\LogdnaFormatter();
-    }
-
-    private function getCurrentTimeInMilliseconds(): string
-    {
-        $time = \microtime();
-        $parts = \explode(' ', $time, 2);
-        return $parts[1] . \str_pad((string) \round(1000.0 * (float) $parts[0]), 3, '0', \STR_PAD_LEFT);
     }
 }


### PR DESCRIPTION
As discussedi in #21 this implementation takes the now value from system time and sends it to logdna in milliseonds as per documentation (https://docs.mezmo.com/log-analysis-api#ingest)

I also added the possibility to turn the time drift calculation off by not sending the now parameter
```php
$handler->setIncludeRequestTime(false);
```

