### PR TITLE
Allow pass Monolog\Level enum instance into LogdnaHandler constructor (update typedoc)

### DIFF
--- a/src/Monolog/Handler/LogdnaHandler.php
+++ b/src/Monolog/Handler/LogdnaHandler.php
@@ -91,7 +91,7 @@ class LogdnaHandler extends \Monolog\Handler\AbstractProcessingHandler
     /**
      * @param string $ingestion_key
      * @param string $hostname
-     * @param int $level
+     * @param int|string|\Monolog\Level $level
      * @param bool $bubble
      */
     public function __construct($ingestion_key, $hostname, $level = \Monolog\Logger::DEBUG, bool $bubble = true)


### PR DESCRIPTION
Since monolog 3, it is possible to pass `\Monolog\Level` into the `$level` parameter of constructor of `\Monolog\Handler\AbstractHandler` and consequently the `LogdnaHandler`.

Althouth it is practically possible now since the types are not enforced at runtime, static analysis tools may report issues when instantiating the handler with `Level` instance.

monolog allowed 
* `int` in 1.x
* `int|string` in 2.x
* `int|string|Level` in 3.x

https://github.com/Seldaek/monolog/blob/3.0.0/src/Monolog/Handler/AbstractHandler.php#L36

since 3.x version of this lib supports only 3.x version of monolog, we should match the type of monolog 3.x
